### PR TITLE
Poing 7 fixes

### DIFF
--- a/data/whdl/game-notwhdl/Poing7.run
+++ b/data/whdl/game-notwhdl/Poing7.run
@@ -1,7 +1,7 @@
 IF NOT EXISTS WHDSaves:poing7
   makedir WHDSaves:poing7
-  copy WHD:N/Poing7/default.levels WHDSaves:poing7
-  copy WHD:N/Poing7/default.scores WHDSaves:poing7
+  ;Copy the jb1 level set, there are others available:
+  copy WHD:N/Poing7/jb1.levels WHDSaves:poing7 
 EndIF
 assign POING: WHDSaves:poing7
 cd WHD:N/Poing7


### PR DESCRIPTION
• The script didn't work, it just sent you back to AGS since it failed — Poing 7 has a different structure than the others. (It might work on your local version if you probably created/copied these files to the save directory)
• Poing 7 doesn't define a default.levels file, so we have to pick one (ReadMe file mentions jb1.levels, so I picked that one — Poing 6 uses jb2, there's also g10.levels and gerske.levels, plus Poing 1/4/5 levels)
• There's no default.scores file, and since they are incompatible across level sets, it's probably better to just let the game create one when launched, so I removed that line